### PR TITLE
Convert render functions to using pipeline enums rather than OPENGL directly

### DIFF
--- a/src/DH.cpp
+++ b/src/DH.cpp
@@ -1,0 +1,13 @@
+#include "DH.h"
+
+using namespace glm;
+glm::mat4 DH::createTransformation(float a, float alpha, float d, float theta){
+    return mat4(0, 2, 3, 4,
+                0, 6, 7, 8,
+                0, 10,11,12,
+                0,14,15,16);
+}
+
+glm::mat4 DH::forwardKinematics(const std::vector<glm::vec4>& dh_params){
+
+}

--- a/src/DH.cpp
+++ b/src/DH.cpp
@@ -1,13 +1,19 @@
 #include "DH.h"
 
 using namespace glm;
-glm::mat4 DH::createTransformation(float a, float alpha, float d, float theta){
-    return mat4(0, 2, 3, 4,
-                0, 6, 7, 8,
-                0, 10,11,12,
-                0,14,15,16);
+mat4 DH::createTransformation(float theta, float alpha, float d, float a){
+    return transpose(mat4(
+                cos(theta),             -sin(theta),                0,          a,
+                sin(theta)*cos(alpha), cos(theta)*cos(alpha), -sin(alpha), -d*sin(alpha),
+                sin(theta)*sin(alpha), cos(theta)*sin(alpha), cos(alpha),   d*cos(alpha),
+                0,                          0,                        0,           1
+            ));
 }
 
-glm::mat4 DH::forwardKinematics(const std::vector<glm::vec4>& dh_params){
-
+mat4 DH::forwardKinematics(const std::vector<glm::vec4>& dh_params){
+    mat4 result = mat4(1);
+    for(auto tuple : dh_params){
+        result = result * createTransformation(tuple[0], tuple[1], tuple[2], tuple[3]);
+    }
+    return result;
 }

--- a/src/DH.h
+++ b/src/DH.h
@@ -1,9 +1,8 @@
 #pragma once
-#include "util.h"
 #include <glm/glm.hpp>
 #include <vector>
 
-static class DH {
+class DH {
 public:
     static glm::mat4 createTransformation(float a, float alpha, float d, float theta);
     static glm::mat4 forwardKinematics(const std::vector<glm::vec4>& dh_params);

--- a/src/DH.h
+++ b/src/DH.h
@@ -7,3 +7,13 @@ public:
     static glm::mat4 createTransformation(float a, float alpha, float d, float theta);
     static glm::mat4 forwardKinematics(const std::vector<glm::vec4>& dh_params);
 };
+
+class Kinematics {
+//modified DH
+private:
+    std::vector<glm::vec4> dh_params;
+public:
+    Kinematics(std::vector<glm::vec4> dh_params = std::vector<glm::vec4>());
+    
+
+};

--- a/src/DH.h
+++ b/src/DH.h
@@ -1,0 +1,10 @@
+#pragma once
+#include "util.h"
+#include <glm/glm.hpp>
+#include <vector>
+
+static class DH {
+public:
+    static glm::mat4 createTransformation(float a, float alpha, float d, float theta);
+    static glm::mat4 forwardKinematics(const std::vector<glm::vec4>& dh_params);
+};

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -20,7 +20,9 @@
 #include"imgui_impl_opengl3.h"
 #include <stdexcept>
 #include "Logger.h"
+#include <glm/gtx/string_cast.hpp>
 
+#include "DH.h"
 const unsigned int width = 800;
 const unsigned int height = 800;
 
@@ -77,6 +79,7 @@ int main()
 	glEnable(GL_DEPTH_TEST);
 
 	Logger::getInstance().log(LOG_INFO, "Starting main loop");
+	Logger::getInstance().log(LOG_INFO, glm::to_string(DH::forwardKinematics({{0,glm::radians(45.f),3,0},{glm::radians(90.f),0,5,0},{0,glm::radians(45.f),0,2},{glm::radians(30.f),glm::radians(-10.f),2,0}}) ));
 
 	// Main while loop
 	while (!glfwWindowShouldClose(renderer.getWindow()))

--- a/src/graphics/GUI.cpp
+++ b/src/graphics/GUI.cpp
@@ -31,7 +31,7 @@ void GUI::buildMenuBar(){
 					if(file != ""){
 						Model* mesh = new ObjModel(file);
 						mesh->setTexture(popupExplorer(".jpg"));
-						mesh->setRenderType(GL_TRIANGLES);
+						mesh->setRenderPipeline(PL_TRIANGLES);
 						scene->addModel(mesh);
 					}
 				}

--- a/src/graphics/GUI.cpp
+++ b/src/graphics/GUI.cpp
@@ -31,7 +31,7 @@ void GUI::buildMenuBar(){
 					if(file != ""){
 						Model* mesh = new ObjModel(file);
 						mesh->setTexture(popupExplorer(".jpg"));
-						mesh->setRenderPipeline(PL_TRIANGLES);
+						mesh->setRenderPipeline(PL_MESH);
 						scene->addModel(mesh);
 					}
 				}

--- a/src/graphics/Mesh.cpp
+++ b/src/graphics/Mesh.cpp
@@ -517,8 +517,9 @@ void ObjModel::buildGUI(){
 		{"MESH", PL_TRIANGLES},
 		{"LINES", PL_LINES},
 		{"LINE_LOOP", PL_LINE_LOOP},
+		{"LINE STRIP", PL_LINE_STRIP},
 		{"MESH OVERLAY", PL_TRIANGLES_OVERLAY},
-		{"LINE STRIP", PL_LINE_STRIP}
+		{"MESH SHADELESS", PL_TRIANGLES_SHADELESS}
 	};
 	
 	for(auto pair : selectablePipelines){

--- a/src/graphics/Mesh.cpp
+++ b/src/graphics/Mesh.cpp
@@ -34,7 +34,7 @@ void Model::doRenderPipeline(Renderer& renderer, RenderPipeline renderformat ,co
 			_render(renderer, &Renderer::renderHighlight, model_transform, normal_transform, GL_TRIANGLES);
 			return;
 		case PL_TRIANGLES_SHADELESS:
-			_render(renderer, &Renderer::renderModel, model_transform, normal_transform, GL_TRIANGLES);
+			_render(renderer, &Renderer::renderModelShadeless, model_transform, normal_transform, GL_TRIANGLES);
 			return;
 		case PL_TRIANGLES_OVERLAY:
 			_render(renderer, &Renderer::renderOverlay, model_transform, normal_transform, GL_TRIANGLES);

--- a/src/graphics/Mesh.cpp
+++ b/src/graphics/Mesh.cpp
@@ -483,7 +483,7 @@ void Model::buildGUI(){
 	}
 	}
 	// Pop into next line if no room
-	if(ImGui::GetContentRegionAvail().x > 330)
+	if(ImGui::GetContentRegionAvail().x - ImGui::GetItemRectSize().x > 50)
 		ImGui::SameLine();
 	ImGui::PushID("use_degrees");
 	ImGui::SetNextItemWidth(50);
@@ -522,11 +522,21 @@ void ObjModel::buildGUI(){
 		{"MESH SHADELESS", PL_TRIANGLES_SHADELESS}
 	};
 	
+	float accum_width = 0;
 	for(auto pair : selectablePipelines){
 		if(ImGui::RadioButton(pair.first.c_str(), render_pipeline == pair.second)){
 			render_pipeline = pair.second;
 		}
-		ImGui::SameLine();
+		accum_width += ImGui::GetItemRectSize().x;
+		if(accum_width > ImGui::GetContentRegionAvail().x - 100){
+			accum_width = 0;
+		}
+		else{
+			ImGui::SameLine();
+		}
+	}
+	if(accum_width != 0){
+		ImGui::NewLine();
 	}
 }
 

--- a/src/graphics/Mesh.cpp
+++ b/src/graphics/Mesh.cpp
@@ -21,7 +21,7 @@ std::string extractFileName(const std::string& filedir) {
 	return filedir.substr(start, end);
 }
 
-void Model::render(Renderer& renderer, RenderPipeline renderformat ,const glm::mat4& model_transform, const glm::mat4& normal_transform){
+void Model::doRenderPipeline(Renderer& renderer, RenderPipeline renderformat ,const glm::mat4& model_transform, const glm::mat4& normal_transform){
 	//Default thing to do when calling render
 	switch(renderformat){
 		case PL_TRIANGLES:
@@ -38,6 +38,14 @@ void Model::render(Renderer& renderer, RenderPipeline renderformat ,const glm::m
 			return;
 		case PL_TRIANGLES_OVERLAY:
 			_render(renderer, &Renderer::renderOverlay, model_transform, normal_transform, GL_TRIANGLES);
+			return;
+		case PL_NONE:
+			return;
+		case PL_OVERRIDDEN:
+			//switch to own pipeline if it doesn't cause infinite recursion
+			if(this->render_pipeline != PL_OVERRIDDEN){
+				doRenderPipeline(renderer, this->render_pipeline, model_transform, normal_transform);
+			}
 			return;
 	}
 }
@@ -416,12 +424,22 @@ void GroupModel::addCopy(const Model* const model){
 
 void GroupModel::_render(Renderer& renderer, RenderFunc(renderer_func), const glm::mat4& model_transform, const glm::mat4& normal_transform, GLuint render_mode){
 	if(render_mode == -1){
-		render_mode = PL_TO_GL(render_pipeline);
+		render_mode = PL_TO_GL(this->render_pipeline);
 	}
 	for(Model* model : models){
 		model->_render(renderer, renderer_func, model_transform * getFullTransformation(), normal_transform * getFullNormalTransformation(), render_mode);
 	}
 }
+
+void GroupModel::doRenderPipeline(Renderer& renderer, RenderPipeline renderformat ,const glm::mat4& model_transform, const glm::mat4& normal_transform){
+	if(renderformat == PL_OVERRIDDEN){
+		renderformat = this->render_pipeline;
+	}
+	for(Model* model : models){
+		model->doRenderPipeline(renderer, renderformat, model_transform, normal_transform);
+	}
+}
+
 
 GroupModel* demoFoxHat(){
 	Model* mesh = new ObjModel("resources\\fox.obj", "resources\\UVMap.png");

--- a/src/graphics/Mesh.cpp
+++ b/src/graphics/Mesh.cpp
@@ -494,7 +494,6 @@ void Model::buildGUI(){
 	if (DragFloat3Lock("Scale", scale, _gui_scale_state)){
 		setScale(scale);
 	}
-	ImGui::Checkbox("Overlay draw", &overlay);
 }
 
 void ObjModel::buildGUI(){

--- a/src/graphics/Mesh.cpp
+++ b/src/graphics/Mesh.cpp
@@ -455,6 +455,7 @@ void Model::buildGUI(){
 	if (DragFloat3Lock("Scale", scale, _gui_scale_state)){
 		setScale(scale);
 	}
+	ImGui::Checkbox("Overlay draw", &overlay);
 }
 
 void ObjModel::buildGUI(){

--- a/src/graphics/Mesh.cpp
+++ b/src/graphics/Mesh.cpp
@@ -21,6 +21,27 @@ std::string extractFileName(const std::string& filedir) {
 	return filedir.substr(start, end);
 }
 
+void Model::render(Renderer& renderer, RenderPipeline renderformat ,const glm::mat4& model_transform, const glm::mat4& normal_transform){
+	//Default thing to do when calling render
+	switch(renderformat){
+		case PL_TRIANGLES:
+		case PL_LINES:
+		case PL_LINE_LOOP:
+		case PL_LINE_STRIP:
+			_render(renderer, &Renderer::renderModel, model_transform, normal_transform, PL_TO_GL(renderformat));
+			return;
+		case PL_TRIANGLES_HIGHLIGHT:
+			_render(renderer, &Renderer::renderHighlight, model_transform, normal_transform, GL_TRIANGLES);
+			return;
+		case PL_TRIANGLES_SHADELESS:
+			_render(renderer, &Renderer::renderModel, model_transform, normal_transform, GL_TRIANGLES);
+			return;
+		case PL_TRIANGLES_OVERLAY:
+			_render(renderer, &Renderer::renderOverlay, model_transform, normal_transform, GL_TRIANGLES);
+			return;
+	}
+}
+
 ObjModel::ObjModel() : Model() {name = "objModel";};
 ObjModel::ObjModel(const std::string& filedir) : Model() {
 	setModel(filedir);
@@ -66,9 +87,9 @@ void Model::setTexture(const std::string& texture_dir){
     texture.generate(texture_dir, GL_TEXTURE_2D, GL_TEXTURE0, GL_RGBA, GL_UNSIGNED_BYTE);
 }
 
-void ObjModel::render(Renderer& renderer, RenderFunc(renderer_func), const glm::mat4& model_transform, const glm::mat4& normal_transform, GLuint render_mode){
+void ObjModel::_render(Renderer& renderer, RenderFunc(renderer_func), const glm::mat4& model_transform, const glm::mat4& normal_transform, GLuint render_mode){
 	if(render_mode == -1){
-		render_mode = this->render_type;
+		render_mode = PL_TO_GL(this->render_pipeline);
 	}
 	//Call renderer with the chosen render call (usually renderer.renderModel)
 	//Overrides the transformations.
@@ -393,18 +414,18 @@ void GroupModel::addCopy(const Model* const model){
 	models.push_back(new_model);
 }
 
-void GroupModel::render(Renderer& renderer, RenderFunc(renderer_func), const glm::mat4& model_transform, const glm::mat4& normal_transform, GLuint render_mode){
+void GroupModel::_render(Renderer& renderer, RenderFunc(renderer_func), const glm::mat4& model_transform, const glm::mat4& normal_transform, GLuint render_mode){
 	if(render_mode == -1){
-		render_mode = this->render_type;
+		render_mode = PL_TO_GL(render_pipeline);
 	}
 	for(Model* model : models){
-		model->render(renderer, renderer_func, model_transform * getFullTransformation(), normal_transform * getFullNormalTransformation(), render_mode);
+		model->_render(renderer, renderer_func, model_transform * getFullTransformation(), normal_transform * getFullNormalTransformation(), render_mode);
 	}
 }
 
 GroupModel* demoFoxHat(){
 	Model* mesh = new ObjModel("resources\\fox.obj", "resources\\UVMap.png");
-    mesh->setRenderType(GL_TRIANGLES);
+    mesh->setRenderPipeline(PL_TRIANGLES);
     mesh->setScale(glm::vec3(1.,0.5,1.));
     mesh->setPosition(glm::vec3(0.0,0,0));
 
@@ -475,12 +496,20 @@ void ObjModel::buildGUI(){
 	}
 	ImGui::Separator();
 
-	int _type = render_type;
-	ImGui::RadioButton("TRIANGLES", &_type, GL_TRIANGLES); ImGui::SameLine();
-	ImGui::RadioButton("LINES", &_type, GL_LINES); ImGui::SameLine();
-	ImGui::RadioButton("LINE_STRIP", &_type, GL_LINE_STRIP); ImGui::SameLine();
-	ImGui::RadioButton("LINES_LOOP", &_type, GL_LINE_LOOP);
-	render_type = _type;
+	const std::map<std::string, RenderPipeline> selectablePipelines = {
+		{"MESH", PL_TRIANGLES},
+		{"LINES", PL_LINES},
+		{"LINE_LOOP", PL_LINE_LOOP},
+		{"MESH OVERLAY", PL_TRIANGLES_OVERLAY},
+		{"LINE STRIP", PL_LINE_STRIP}
+	};
+	
+	for(auto pair : selectablePipelines){
+		if(ImGui::RadioButton(pair.first.c_str(), render_pipeline == pair.second)){
+			render_pipeline = pair.second;
+		}
+		ImGui::SameLine();
+	}
 }
 
 void GroupModel::buildChildrenDropdownGUI(){

--- a/src/graphics/Mesh.cpp
+++ b/src/graphics/Mesh.cpp
@@ -24,19 +24,19 @@ std::string extractFileName(const std::string& filedir) {
 void Model::doRenderPipeline(Renderer& renderer, RenderPipeline renderformat ,const glm::mat4& model_transform, const glm::mat4& normal_transform){
 	//Default thing to do when calling render
 	switch(renderformat){
-		case PL_TRIANGLES:
+		case PL_MESH:
 		case PL_LINES:
 		case PL_LINE_LOOP:
 		case PL_LINE_STRIP:
 			_render(renderer, &Renderer::renderModel, model_transform, normal_transform, PL_TO_GL(renderformat));
 			return;
-		case PL_TRIANGLES_HIGHLIGHT:
+		case PL_MESH_HIGHLIGHT:
 			_render(renderer, &Renderer::renderHighlight, model_transform, normal_transform, GL_TRIANGLES);
 			return;
-		case PL_TRIANGLES_SHADELESS:
+		case PL_MESH_SHADELESS:
 			_render(renderer, &Renderer::renderModelShadeless, model_transform, normal_transform, GL_TRIANGLES);
 			return;
-		case PL_TRIANGLES_OVERLAY:
+		case PL_MESH_OVERLAY:
 			_render(renderer, &Renderer::renderOverlay, model_transform, normal_transform, GL_TRIANGLES);
 			return;
 		case PL_NONE:
@@ -443,7 +443,7 @@ void GroupModel::doRenderPipeline(Renderer& renderer, RenderPipeline renderforma
 
 GroupModel* demoFoxHat(){
 	Model* mesh = new ObjModel("resources\\fox.obj", "resources\\UVMap.png");
-    mesh->setRenderPipeline(PL_TRIANGLES);
+    mesh->setRenderPipeline(PL_MESH);
     mesh->setScale(glm::vec3(1.,0.5,1.));
     mesh->setPosition(glm::vec3(0.0,0,0));
 
@@ -514,12 +514,12 @@ void ObjModel::buildGUI(){
 	ImGui::Separator();
 
 	const std::map<std::string, RenderPipeline> selectablePipelines = {
-		{"MESH", PL_TRIANGLES},
+		{"MESH", PL_MESH},
 		{"LINES", PL_LINES},
 		{"LINE_LOOP", PL_LINE_LOOP},
 		{"LINE STRIP", PL_LINE_STRIP},
-		{"MESH OVERLAY", PL_TRIANGLES_OVERLAY},
-		{"MESH SHADELESS", PL_TRIANGLES_SHADELESS}
+		{"MESH OVERLAY", PL_MESH_OVERLAY},
+		{"MESH SHADELESS", PL_MESH_SHADELESS}
 	};
 	
 	float accum_width = 0;

--- a/src/graphics/Mesh.h
+++ b/src/graphics/Mesh.h
@@ -23,13 +23,13 @@ typedef enum {
     //pass to models to have them use their own pipeline.
     PL_OVERRIDDEN = -2,
     PL_NONE = -1,
-    PL_TRIANGLES = GL_TRIANGLES,
+    PL_MESH = GL_TRIANGLES,
     PL_LINES = GL_LINES,
     PL_LINE_STRIP = GL_LINE_STRIP,
     PL_LINE_LOOP = GL_LINE_LOOP,
-    PL_TRIANGLES_SHADELESS = GL_TRIANGLES | 1 << 4,
-    PL_TRIANGLES_HIGHLIGHT = GL_TRIANGLES | 2 << 4,
-    PL_TRIANGLES_OVERLAY = GL_TRIANGLES | 3 << 4
+    PL_MESH_SHADELESS = GL_TRIANGLES | 1 << 4,
+    PL_MESH_HIGHLIGHT = GL_TRIANGLES | 2 << 4,
+    PL_MESH_OVERLAY = GL_TRIANGLES | 3 << 4
 } RenderPipeline;
 
 inline GLuint PL_TO_GL(RenderPipeline pl){
@@ -54,7 +54,7 @@ protected:
 
     glm::vec4 color = glm::vec4(1.,1.,1.,1.);
 
-    RenderPipeline render_pipeline = PL_TRIANGLES;
+    RenderPipeline render_pipeline = PL_MESH;
 
     std::string name;
 

--- a/src/graphics/Mesh.h
+++ b/src/graphics/Mesh.h
@@ -29,7 +29,7 @@ typedef enum {
     PL_LINE_LOOP = GL_LINE_LOOP,
     PL_TRIANGLES_SHADELESS = GL_TRIANGLES | 1 << 4,
     PL_TRIANGLES_HIGHLIGHT = GL_TRIANGLES | 2 << 4,
-    PL_TRIANGLES_OVERLAY = GL_TRIANGLES | 3 << 4,
+    PL_TRIANGLES_OVERLAY = GL_TRIANGLES | 3 << 4
 } RenderPipeline;
 
 inline GLuint PL_TO_GL(RenderPipeline pl){

--- a/src/graphics/Mesh.h
+++ b/src/graphics/Mesh.h
@@ -18,6 +18,21 @@ class VertexData{
 };
 #define RenderFunc(name) void (Renderer::*name)(GLuint render_mode, GLsizeiptr indices_count, const VAO* const vao, const Texture* const texture, const glm::vec4& color, const glm::mat4& model_transform, const glm::mat4& normal_transform)
 
+//I've decided to put a wrapper over GL_[RENDER] types because i want to pass relevant choices to my renderer without adding infinitely many and conflicting parameters
+typedef enum {
+    PL_TRIANGLES = GL_TRIANGLES,
+    PL_LINES = GL_LINES,
+    PL_LINE_STRIP = GL_LINE_STRIP,
+    PL_LINE_LOOP = GL_LINE_LOOP,
+    PL_TRIANGLES_SHADELESS = GL_TRIANGLES | 1 << 4,
+    PL_TRIANGLES_HIGHLIGHT = GL_TRIANGLES | 2 << 4,
+    PL_TRIANGLES_OVERLAY = GL_TRIANGLES | 3 << 4,
+} RenderPipeline;
+
+inline GLuint PL_TO_GL(RenderPipeline pl){
+    return pl & 0b111;
+}
+
 class Model {
 protected:
     Texture texture;
@@ -36,7 +51,7 @@ protected:
 
     glm::vec4 color = glm::vec4(1.,1.,1.,1.);
 
-    GLuint render_type = GL_TRIANGLES;
+    RenderPipeline render_pipeline = PL_TRIANGLES;
 
     std::string name;
 
@@ -64,14 +79,15 @@ protected:
 public:
     Model();
 
-    void setRenderType(GLuint new_type) {render_type = new_type;};
+    void setRenderPipeline(RenderPipeline pipeline) {render_pipeline = pipeline;};
     void setTexture(const std::string& texturedir);
     void setTexture(const Texture& texture) {this->texture = texture;};
     bool hasTexture() {return texture.exists();};
     
     // virtual void render(Renderer& renderer, RenderFunc(renderer_func) = Renderer::renderModel) = 0;
     //applies transforms on the render, changes the set render_mode
-    virtual void render(Renderer& renderer, RenderFunc(render_func) = &Renderer::renderModel,
+    virtual void render(Renderer& renderer, RenderPipeline renderformat = PL_TRIANGLES ,const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1));
+    virtual void _render(Renderer& renderer, RenderFunc(render_func) = &Renderer::renderModel,
                         const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1), GLuint render_mode = -1) = 0;
 
     virtual void destroy();
@@ -118,7 +134,7 @@ class ObjModel : public Model{
 
     // virtual void render(Renderer& renderer, RenderFunc(renderer_func) = Renderer::renderModel) override;
     //applies transforms on the render, changes the set render_mode
-    virtual void render(Renderer& renderer, RenderFunc(renderer_func) = &Renderer::renderModel, const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1), GLuint render_mode = -1) override;
+    virtual void _render(Renderer& renderer, RenderFunc(renderer_func) = &Renderer::renderModel, const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1), GLuint render_mode = -1) override;
 
     
     virtual void buildGUI() override;
@@ -186,7 +202,7 @@ public:
     virtual void addModel(Model* model);
     virtual void addCopy(const Model* const model);
     // virtual void render(Renderer& renderer, RenderFunc(render_func) = Renderer::renderModel) override;
-    virtual void render(Renderer& renderer, RenderFunc(renderer_func) = &Renderer::renderModel, const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1), GLuint render_mode = -1) override;
+    virtual void _render(Renderer& renderer, RenderFunc(renderer_func) = &Renderer::renderModel, const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1), GLuint render_mode = -1) override;
     //virtual void buildGUI() override;
 
     virtual void destroy() override;

--- a/src/graphics/Mesh.h
+++ b/src/graphics/Mesh.h
@@ -58,8 +58,6 @@ protected:
 
     std::string name;
 
-    bool overlay = false;   //render above everything else and without shading.
-
     void applyWorldTransformation(const glm::mat4 &transformation);
 	void applyModelTransformation(const glm::mat4 &transformation);
 	void applyWorldNormalTransformation(const glm::mat4 &transformation_inv);
@@ -89,7 +87,7 @@ public:
     
     // virtual void render(Renderer& renderer, RenderFunc(renderer_func) = Renderer::renderModel) = 0;
     //applies transforms on the render, changes the set render_mode
-    virtual void doRenderPipeline(Renderer& renderer, RenderPipeline renderformat = PL_TRIANGLES ,const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1));
+    virtual void doRenderPipeline(Renderer& renderer, RenderPipeline renderformat = PL_OVERRIDDEN ,const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1));
     virtual void _render(Renderer& renderer, RenderFunc(render_func) = &Renderer::renderModel,
                         const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1), GLuint render_mode = -1) = 0;
 
@@ -108,8 +106,6 @@ public:
     glm::vec3 getPosition() {return position;};
     glm::vec3 getAngles() {return yaw_pitch_roll;};
     glm::vec3 getScale() {return size;};
-    void setOverlay(bool value) {this->overlay = value;};
-    bool isOverlay() {return this->overlay;};
     void setName(const std::string& name) {this->name = name;};
     std::string getName() const {return name;};
 
@@ -206,7 +202,7 @@ public:
     virtual void addModel(Model* model);
     virtual void addCopy(const Model* const model);
     // virtual void render(Renderer& renderer, RenderFunc(render_func) = Renderer::renderModel) override;
-    virtual void doRenderPipeline(Renderer& renderer, RenderPipeline renderformat = PL_TRIANGLES ,const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1)) override;
+    virtual void doRenderPipeline(Renderer& renderer, RenderPipeline renderformat = PL_OVERRIDDEN ,const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1)) override;
     virtual void _render(Renderer& renderer, RenderFunc(renderer_func) = &Renderer::renderModel, const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1), GLuint render_mode = -1) override;
     //virtual void buildGUI() override;
 

--- a/src/graphics/Mesh.h
+++ b/src/graphics/Mesh.h
@@ -20,6 +20,9 @@ class VertexData{
 
 //I've decided to put a wrapper over GL_[RENDER] types because i want to pass relevant choices to my renderer without adding infinitely many and conflicting parameters
 typedef enum {
+    //pass to models to have them use their own pipeline.
+    PL_OVERRIDDEN = -2,
+    PL_NONE = -1,
     PL_TRIANGLES = GL_TRIANGLES,
     PL_LINES = GL_LINES,
     PL_LINE_STRIP = GL_LINE_STRIP,
@@ -86,7 +89,7 @@ public:
     
     // virtual void render(Renderer& renderer, RenderFunc(renderer_func) = Renderer::renderModel) = 0;
     //applies transforms on the render, changes the set render_mode
-    virtual void render(Renderer& renderer, RenderPipeline renderformat = PL_TRIANGLES ,const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1));
+    virtual void doRenderPipeline(Renderer& renderer, RenderPipeline renderformat = PL_TRIANGLES ,const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1));
     virtual void _render(Renderer& renderer, RenderFunc(render_func) = &Renderer::renderModel,
                         const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1), GLuint render_mode = -1) = 0;
 
@@ -134,6 +137,7 @@ class ObjModel : public Model{
 
     // virtual void render(Renderer& renderer, RenderFunc(renderer_func) = Renderer::renderModel) override;
     //applies transforms on the render, changes the set render_mode
+    //virtual void doRenderPipeline(Renderer& renderer, RenderPipeline renderformat = PL_TRIANGLES ,const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1)) override;
     virtual void _render(Renderer& renderer, RenderFunc(renderer_func) = &Renderer::renderModel, const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1), GLuint render_mode = -1) override;
 
     
@@ -202,6 +206,7 @@ public:
     virtual void addModel(Model* model);
     virtual void addCopy(const Model* const model);
     // virtual void render(Renderer& renderer, RenderFunc(render_func) = Renderer::renderModel) override;
+    virtual void doRenderPipeline(Renderer& renderer, RenderPipeline renderformat = PL_TRIANGLES ,const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1)) override;
     virtual void _render(Renderer& renderer, RenderFunc(renderer_func) = &Renderer::renderModel, const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1), GLuint render_mode = -1) override;
     //virtual void buildGUI() override;
 

--- a/src/graphics/Mesh.h
+++ b/src/graphics/Mesh.h
@@ -40,6 +40,8 @@ protected:
 
     std::string name;
 
+    bool overlay = false;   //render above everything else and without shading.
+
     void applyWorldTransformation(const glm::mat4 &transformation);
 	void applyModelTransformation(const glm::mat4 &transformation);
 	void applyWorldNormalTransformation(const glm::mat4 &transformation_inv);
@@ -87,7 +89,8 @@ public:
     glm::vec3 getPosition() {return position;};
     glm::vec3 getAngles() {return yaw_pitch_roll;};
     glm::vec3 getScale() {return size;};
-    
+    void setOverlay(bool value) {this->overlay = value;};
+    bool isOverlay() {return this->overlay;};
     void setName(const std::string& name) {this->name = name;};
     std::string getName() const {return name;};
 

--- a/src/graphics/MeshEx.cpp
+++ b/src/graphics/MeshEx.cpp
@@ -103,10 +103,10 @@ ConfigableGroupModel* demoAxis(float bar_radius, float bar_length, float arrow_r
         {"barRadius", new ConfigVariable<float>("bar radius", bar_radius)},
         {"arrowLength", new ConfigVariable<float>("arrow length", arrow_length)},
         {"arrowRadius", new ConfigVariable<float>("arrow radius", arrow_radius)}
-    }, [](std::vector<Model*>& models, std::map<std::string, ConfigVariableBase*>& params) {
+    }, [size](std::vector<Model*>& models, std::map<std::string, ConfigVariableBase*>& params) {
         float bar_radius = GET_CONFIG_VARIABLE(float, params["barRadius"]);
         float arrow_length = GET_CONFIG_VARIABLE(float, params["arrowLength"]);
-        float bar_length = 1 - arrow_length;
+        float bar_length = size - arrow_length;
         float arrow_radius = GET_CONFIG_VARIABLE(float, params["arrowRadius"]);
         // x bar
         models[0]->setPosition(glm::vec3(bar_length/2,0,0));
@@ -248,11 +248,13 @@ ConfigableGroupModel* arrow(float bar_radius, float bar_length, float arrow_radi
 
 // For iterating these demos
 ConfigableGroupModel* _demoAxis() { return demoAxis(); }
+ConfigableGroupModel* _demoAxisMini() { return demoAxis(0.002,0.025,0.01,0.05); }
 ConfigableGroupModel* _stairModel() {   return stairModel(); }
 ConfigableGroupModel* _arrow() {   return arrow(); }
 
 const std::map<std::string, ConfigableGroupModel*(*)()> demoFuncList = {
-    {"Axis", _demoAxis},
+    {"Axis 1.00m", _demoAxis},
+    {"Axis 0.05m", _demoAxisMini},
     {"Stair", _stairModel},
     {"Arrow", _arrow}
 };

--- a/src/graphics/MeshEx.cpp
+++ b/src/graphics/MeshEx.cpp
@@ -148,7 +148,7 @@ ConfigableGroupModel* demoAxis(float bar_radius, float bar_length, float arrow_r
     });
     group->updateModels();
     group->setName("axis");
-    group->setOverlay(true);
+    group->setRenderPipeline(PL_TRIANGLES_OVERLAY);
 
     return group;
 }

--- a/src/graphics/MeshEx.cpp
+++ b/src/graphics/MeshEx.cpp
@@ -148,7 +148,7 @@ ConfigableGroupModel* demoAxis(float bar_radius, float bar_length, float arrow_r
     });
     group->updateModels();
     group->setName("axis");
-    group->setRenderPipeline(PL_TRIANGLES_OVERLAY);
+    group->setRenderPipeline(PL_MESH_OVERLAY);
 
     return group;
 }

--- a/src/graphics/MeshEx.cpp
+++ b/src/graphics/MeshEx.cpp
@@ -148,6 +148,7 @@ ConfigableGroupModel* demoAxis(float bar_radius, float bar_length, float arrow_r
     });
     group->updateModels();
     group->setName("axis");
+    group->setOverlay(true);
 
     return group;
 }

--- a/src/graphics/MeshEx.cpp
+++ b/src/graphics/MeshEx.cpp
@@ -249,13 +249,13 @@ ConfigableGroupModel* arrow(float bar_radius, float bar_length, float arrow_radi
 
 // For iterating these demos
 ConfigableGroupModel* _demoAxis() { return demoAxis(); }
-ConfigableGroupModel* _demoAxisMini() { return demoAxis(0.002,0.025,0.01,0.05); }
+ConfigableGroupModel* _demoAxisMini() { return demoAxis(0.004,0.05,0.02,0.1); }
 ConfigableGroupModel* _stairModel() {   return stairModel(); }
 ConfigableGroupModel* _arrow() {   return arrow(); }
 
 const std::map<std::string, ConfigableGroupModel*(*)()> demoFuncList = {
     {"Axis 1.00m", _demoAxis},
-    {"Axis 0.05m", _demoAxisMini},
+    {"Axis 0.1m", _demoAxisMini},
     {"Stair", _stairModel},
     {"Arrow", _arrow}
 };

--- a/src/graphics/MeshPrimitive.cpp
+++ b/src/graphics/MeshPrimitive.cpp
@@ -71,7 +71,7 @@ GLuint indices[] = {
 36, 37, 39, 38,
 40, 41, 43, 42
 };
-	this->setRenderType(GL_LINES);
+	this->setRenderPipeline(PL_LINES);
     this->generateMesh(vertices, sizeof(vertices)/sizeof(GLfloat), indices, sizeof(indices)/sizeof(GLuint));
 }
 
@@ -93,7 +93,7 @@ void Primitive::Circle(){
 	for(int i = 0; i < nodes; i++){
 		indices[i] = i;
 	}
-	this->setRenderType(GL_LINE_LOOP);
+	this->setRenderPipeline(PL_LINE_LOOP);
 	this->generateMesh(vertices, sizeof(vertices)/sizeof(GLfloat), indices, sizeof(indices)/sizeof(GLuint));
 };
 
@@ -143,7 +143,7 @@ void Primitive::Cone(){
 		indices[6 * i + 4] = i;
 		indices[6 * i + 5] = top_node;
 	}
-	this->setRenderType(GL_TRIANGLES);
+	this->setRenderPipeline(PL_TRIANGLES);
 	this->generateMesh(vertices, sizeof(vertices)/sizeof(GLfloat), indices, sizeof(indices)/sizeof(GLuint));
 };
 
@@ -215,7 +215,7 @@ void Primitive::Cylinder(){
 		indices[12 * i + 10] = br;
 		indices[12 * i + 11] = bottom_node;
 	}
-	this->setRenderType(GL_TRIANGLES);
+	this->setRenderPipeline(PL_TRIANGLES);
 	this->generateMesh(vertices, sizeof(vertices)/sizeof(GLfloat), indices, sizeof(indices)/sizeof(GLuint));
 };
 
@@ -251,7 +251,7 @@ void Primitive::Cube(){
 		indices[6*i + 5] = 4*i + 1;
 	}
 
-	this->setRenderType(GL_TRIANGLES);
+	this->setRenderPipeline(PL_TRIANGLES);
 	this->generateMesh(vertices, sizeof(vertices)/sizeof(GLfloat), indices, sizeof(indices)/sizeof(GLuint));
 
 }

--- a/src/graphics/MeshPrimitive.cpp
+++ b/src/graphics/MeshPrimitive.cpp
@@ -274,10 +274,10 @@ Primitive::Primitive(PRIM_MODEL model){
 		case PRIM_CYLINDER:
 			Cylinder();
 			break;
-		case PRIM_SPHERE:
 		case PRIM_CUBE:
 			Cube();
 			break;
+		case PRIM_SPHERE:
 		default:
             FromFile(PRIM_MODEL_NAMES.at(model) + ".obj");
 			break;

--- a/src/graphics/MeshPrimitive.cpp
+++ b/src/graphics/MeshPrimitive.cpp
@@ -143,7 +143,7 @@ void Primitive::Cone(){
 		indices[6 * i + 4] = i;
 		indices[6 * i + 5] = top_node;
 	}
-	this->setRenderPipeline(PL_TRIANGLES);
+	this->setRenderPipeline(PL_MESH);
 	this->generateMesh(vertices, sizeof(vertices)/sizeof(GLfloat), indices, sizeof(indices)/sizeof(GLuint));
 };
 
@@ -215,7 +215,7 @@ void Primitive::Cylinder(){
 		indices[12 * i + 10] = br;
 		indices[12 * i + 11] = bottom_node;
 	}
-	this->setRenderPipeline(PL_TRIANGLES);
+	this->setRenderPipeline(PL_MESH);
 	this->generateMesh(vertices, sizeof(vertices)/sizeof(GLfloat), indices, sizeof(indices)/sizeof(GLuint));
 };
 
@@ -251,7 +251,7 @@ void Primitive::Cube(){
 		indices[6*i + 5] = 4*i + 1;
 	}
 
-	this->setRenderPipeline(PL_TRIANGLES);
+	this->setRenderPipeline(PL_MESH);
 	this->generateMesh(vertices, sizeof(vertices)/sizeof(GLfloat), indices, sizeof(indices)/sizeof(GLuint));
 
 }

--- a/src/graphics/Renderer.cpp
+++ b/src/graphics/Renderer.cpp
@@ -49,12 +49,42 @@ void Renderer::windowResizeCallBack(GLFWwindow* window, int width, int height){
 	}
 	aspect_matrix[0][0] = (float)height / width;
 }
+
+void Renderer::_renderPipeline(bool do_blend, int layer, Shader& shader, GLuint render_mode, GLsizeiptr indices_count, const VAO* const vao, const Texture* const texture, const glm::vec4& color, const glm::mat4& model_transform, const glm::mat4& normal_transform){
+	//Preventing code repetition
+
+	//Pass model transforms
+	shader.activate();
+	shader.setMat4("modelTransform", model_transform);
+	shader.setMat4("normalTransform", normal_transform);
+	shader.setMat4("cameraTransform", camera_view);
+	shader.setVec4("color", color);
+
+	//Draw.
+	vao->bind();
+	if (texture != nullptr)	texture->bind();
+	glDrawElements(render_mode, indices_count, GL_UNSIGNED_INT, 0);
+	vao->unbind();
+	if (texture != nullptr)	texture->unbind();
+	shader.deactivate();
+
+}
+
 void Renderer::renderModel(GLuint render_mode, GLsizeiptr indices_count, const VAO* const vao, const Texture* const texture, const glm::vec4& color, const glm::mat4& model_transform, const glm::mat4& normal_transform){
 	//Decide which shader to use
 	bool use_texture = texture != nullptr && texture->exists();
 
 	bool use_color = render_mode == GL_LINES || render_mode == GL_LINE_STRIP || render_mode == GL_LINE_LOOP;
 	Shader& shader = use_color ? color_shader : (use_texture ? tex_shader : no_tex_shader);
+
+	_renderPipeline(false, 0, shader, render_mode, indices_count, vao, texture, color, model_transform, normal_transform);
+}
+
+void Renderer::renderModelShadeless(GLuint render_mode, GLsizeiptr indices_count, const VAO* const vao, const Texture* const texture, const glm::vec4& color, const glm::mat4& model_transform, const glm::mat4& normal_transform){
+	//Decide which shader to use
+	bool use_texture = texture != nullptr && texture->exists();
+
+	Shader& shader = color_shader;
 
 	//Pass model transforms
 	shader.activate();
@@ -71,6 +101,7 @@ void Renderer::renderModel(GLuint render_mode, GLsizeiptr indices_count, const V
 	if (texture != nullptr)	texture->unbind();
 	shader.deactivate();
 }
+
 
 void Renderer::renderHighlight(GLuint render_mode, GLsizeiptr indices_count, const VAO* const vao, const Texture* const texture, const glm::vec4& color, const glm::mat4& model_transform, const glm::mat4& normal_transform){
 	

--- a/src/graphics/Renderer.cpp
+++ b/src/graphics/Renderer.cpp
@@ -13,6 +13,7 @@ Renderer::Renderer(GLFWwindow* window, int width, int height) : tex_shader("reso
 	glEnable(GL_CULL_FACE);
 	glCullFace(GL_BACK);
 	glFrontFace(GL_CCW);
+	glDepthRange(0.1f,1.f);
 }
 
 
@@ -72,14 +73,32 @@ void Renderer::renderHighlight(GLuint render_mode, GLsizeiptr indices_count, con
 
 	//Draw.
 	vao->bind();
-	glDisable(GL_DEPTH_TEST);
+	glDepthRange(0,0.1f);
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 glEnable( GL_BLEND );
 	glDrawElements(GL_TRIANGLES, indices_count, GL_UNSIGNED_INT, 0);
-	glEnable(GL_DEPTH_TEST);
+	glDepthRange(0.1f,1.f);
 glDisable( GL_BLEND );
 
 
 	vao->unbind();
+	shader.deactivate();
+}
+
+void Renderer::renderOverlay(GLuint render_mode, GLsizeiptr indices_count, const VAO* const vao, const Texture* const texture, const glm::vec4& color, const glm::mat4& model_transform, const glm::mat4& normal_transform){
+	Shader& shader = color_shader;
+
+	//Pass model transforms
+	shader.activate();
+	shader.setMat4("modelTransform", model_transform);
+	shader.setMat4("normalTransform", normal_transform);
+	shader.setMat4("cameraTransform", camera_view);
+	shader.setVec4("color", color);
+
+	//Draw.
+	vao->bind();
+	glDepthRange(0,0.1f);
+	glDrawElements(render_mode, indices_count, GL_UNSIGNED_INT, 0);
+	glDepthRange(0.1f,1);
 	shader.deactivate();
 }

--- a/src/graphics/Renderer.cpp
+++ b/src/graphics/Renderer.cpp
@@ -60,6 +60,21 @@ void Renderer::_renderPipeline(bool do_blend, int layer, Shader& shader, GLuint 
 	shader.setMat4("cameraTransform", camera_view);
 	shader.setVec4("color", color);
 
+	if(layer == 0)
+		_depthDefault();
+	if(layer == 1)
+		_depthOverlay();
+	if(layer == 2)
+		_depthClosest();
+
+	if(do_blend){
+		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+		glEnable( GL_BLEND );
+
+	}
+	else{
+		glDisable( GL_BLEND );
+	}
 	//Draw.
 	vao->bind();
 	if (texture != nullptr)	texture->bind();
@@ -67,6 +82,10 @@ void Renderer::_renderPipeline(bool do_blend, int layer, Shader& shader, GLuint 
 	vao->unbind();
 	if (texture != nullptr)	texture->unbind();
 	shader.deactivate();
+
+	//for sanity sake:
+	_depthDefault();
+	glDisable(GL_BLEND);
 
 }
 
@@ -81,67 +100,18 @@ void Renderer::renderModel(GLuint render_mode, GLsizeiptr indices_count, const V
 }
 
 void Renderer::renderModelShadeless(GLuint render_mode, GLsizeiptr indices_count, const VAO* const vao, const Texture* const texture, const glm::vec4& color, const glm::mat4& model_transform, const glm::mat4& normal_transform){
-	//Decide which shader to use
-	bool use_texture = texture != nullptr && texture->exists();
-
-	Shader& shader = color_shader;
-
-	//Pass model transforms
-	shader.activate();
-	shader.setMat4("modelTransform", model_transform);
-	shader.setMat4("normalTransform", normal_transform);
-	shader.setMat4("cameraTransform", camera_view);
-	shader.setVec4("color", color);
-
-	//Draw.
-	vao->bind();
-	if (texture != nullptr)	texture->bind();
-	glDrawElements(render_mode, indices_count, GL_UNSIGNED_INT, 0);
-	vao->unbind();
-	if (texture != nullptr)	texture->unbind();
-	shader.deactivate();
+	_renderPipeline(false, 0, color_shader, render_mode, indices_count, vao, texture, color, model_transform, normal_transform);
 }
 
+void Renderer::renderOverlay(GLuint render_mode, GLsizeiptr indices_count, const VAO* const vao, const Texture* const texture, const glm::vec4& color, const glm::mat4& model_transform, const glm::mat4& normal_transform){
+	_renderPipeline(false, 1, color_shader, render_mode, indices_count, vao, texture, color, model_transform, normal_transform);
+}
 
 void Renderer::renderHighlight(GLuint render_mode, GLsizeiptr indices_count, const VAO* const vao, const Texture* const texture, const glm::vec4& color, const glm::mat4& model_transform, const glm::mat4& normal_transform){
 	
 	Shader& shader = highlight_shader;
-	//Pass model transforms
+	//Pass additional uniform
 	shader.activate();
-	shader.setMat4("modelTransform", model_transform);
-	shader.setMat4("normalTransform", normal_transform);
-	shader.setMat4("cameraTransform", camera_view);
 	shader.setFloat("time", glfwGetTime());
-	shader.setVec4("color", color);
-
-	//Draw.
-	vao->bind();
-	_depthClosest();
-	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-glEnable( GL_BLEND );
-	glDrawElements(GL_TRIANGLES, indices_count, GL_UNSIGNED_INT, 0);
-	_depthDefault();
-glDisable( GL_BLEND );
-
-
-	vao->unbind();
-	shader.deactivate();
-}
-
-void Renderer::renderOverlay(GLuint render_mode, GLsizeiptr indices_count, const VAO* const vao, const Texture* const texture, const glm::vec4& color, const glm::mat4& model_transform, const glm::mat4& normal_transform){
-	Shader& shader = color_shader;
-
-	//Pass model transforms
-	shader.activate();
-	shader.setMat4("modelTransform", model_transform);
-	shader.setMat4("normalTransform", normal_transform);
-	shader.setMat4("cameraTransform", camera_view);
-	shader.setVec4("color", color);
-
-	//Draw.
-	vao->bind();
-	_depthOverlay();
-	glDrawElements(render_mode, indices_count, GL_UNSIGNED_INT, 0);
-	_depthDefault();
-	shader.deactivate();
+	_renderPipeline(true, 2, shader, GL_TRIANGLES, indices_count, vao, nullptr, glm::vec4(1), model_transform, normal_transform);
 }

--- a/src/graphics/Renderer.cpp
+++ b/src/graphics/Renderer.cpp
@@ -1,4 +1,17 @@
 #include"graphics/Renderer.h"
+
+// How i split the depths, all objects are in the 0.2-1f range, overlays are 0.1-0.2, and highlighting the selected object is 0-0.1.
+// Convention: _depthDefault is maintained.
+void _depthDefault(){
+	glDepthRange(0.2f,1.f);
+}
+void _depthOverlay(){
+	glDepthRange(0.1f,0.2f);
+}
+void _depthClosest(){
+	glDepthRange(0.0f,0.1f);
+}
+
 Renderer::Renderer(GLFWwindow* window, int width, int height) : tex_shader("resources/default.vert", "resources/default.frag"),
 																no_tex_shader("resources/default.vert", "resources/default_no_tex.frag"), 
 																color_shader("resources/default.vert", "resources/color.frag"),
@@ -13,9 +26,8 @@ Renderer::Renderer(GLFWwindow* window, int width, int height) : tex_shader("reso
 	glEnable(GL_CULL_FACE);
 	glCullFace(GL_BACK);
 	glFrontFace(GL_CCW);
-	glDepthRange(0.1f,1.f);
+	_depthDefault();
 }
-
 
 void Renderer::clearFrame()
 {
@@ -73,11 +85,11 @@ void Renderer::renderHighlight(GLuint render_mode, GLsizeiptr indices_count, con
 
 	//Draw.
 	vao->bind();
-	glDepthRange(0,0.1f);
+	_depthClosest();
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 glEnable( GL_BLEND );
 	glDrawElements(GL_TRIANGLES, indices_count, GL_UNSIGNED_INT, 0);
-	glDepthRange(0.1f,1.f);
+	_depthDefault();
 glDisable( GL_BLEND );
 
 
@@ -97,8 +109,8 @@ void Renderer::renderOverlay(GLuint render_mode, GLsizeiptr indices_count, const
 
 	//Draw.
 	vao->bind();
-	glDepthRange(0,0.1f);
+	_depthOverlay();
 	glDrawElements(render_mode, indices_count, GL_UNSIGNED_INT, 0);
-	glDepthRange(0.1f,1);
+	_depthDefault();
 	shader.deactivate();
 }

--- a/src/graphics/Renderer.h
+++ b/src/graphics/Renderer.h
@@ -33,6 +33,7 @@ public:
 
     void renderModel(GLuint render_mode, GLsizeiptr indices_count, const VAO* const vao, const Texture* const texture, const glm::vec4& color = glm::vec4(1), const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1));
     void renderHighlight(GLuint render_mode, GLsizeiptr indices_count, const VAO* const vao, const Texture* const texture, const glm::vec4& color = glm::vec4(1), const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1));
+    void renderOverlay(GLuint render_mode, GLsizeiptr indices_count, const VAO* const vao, const Texture* const texture, const glm::vec4& color = glm::vec4(1), const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1));
     void updateCamera(Camera& camera);
     void updateCamera(const glm::mat4& projection, const glm::mat4& view);
     void clearFrame();

--- a/src/graphics/Renderer.h
+++ b/src/graphics/Renderer.h
@@ -31,7 +31,9 @@ public:
     glm::vec2 getWindowShape() {return glm::vec2(width, height);};
     //Shader& getMainShader() {return tex_shader;};
 
+    void _renderPipeline(bool do_blend, int layer, Shader& shader, GLuint render_mode, GLsizeiptr indices_count, const VAO* const vao, const Texture* const texture, const glm::vec4& color = glm::vec4(1), const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1));
     void renderModel(GLuint render_mode, GLsizeiptr indices_count, const VAO* const vao, const Texture* const texture, const glm::vec4& color = glm::vec4(1), const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1));
+    void renderModelShadeless(GLuint render_mode, GLsizeiptr indices_count, const VAO* const vao, const Texture* const texture, const glm::vec4& color = glm::vec4(1), const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1));
     void renderHighlight(GLuint render_mode, GLsizeiptr indices_count, const VAO* const vao, const Texture* const texture, const glm::vec4& color = glm::vec4(1), const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1));
     void renderOverlay(GLuint render_mode, GLsizeiptr indices_count, const VAO* const vao, const Texture* const texture, const glm::vec4& color = glm::vec4(1), const glm::mat4& model_transform = glm::mat4(1), const glm::mat4& normal_transform = glm::mat4(1));
     void updateCamera(Camera& camera);

--- a/src/graphics/Scene.cpp
+++ b/src/graphics/Scene.cpp
@@ -94,7 +94,7 @@ void Scene::handleInputs(Renderer& renderer){
 
 void Scene::render(Renderer& renderer){
     for(Model* model : models){
-        model->render(renderer);
+        model->doRenderPipeline(renderer);
     }
     int i = 0;
     for(Model* model : const_models){
@@ -102,11 +102,11 @@ void Scene::render(Renderer& renderer){
             i++;
             continue;
         }
-        model->render(renderer);
+        model->doRenderPipeline(renderer);
     }
 
     if (selected_model >= 0 && selected_model < models.size() && highlight_selected_model){
-        models[selected_model]->render(renderer, PL_TRIANGLES_HIGHLIGHT);
+        models[selected_model]->doRenderPipeline(renderer, PL_TRIANGLES_HIGHLIGHT);
     }
 }
 

--- a/src/graphics/Scene.cpp
+++ b/src/graphics/Scene.cpp
@@ -1,6 +1,7 @@
 #include"Scene.h"
 #include "graphics/MeshEx.h"
 #include "graphics/Spider.h"
+#include <Logger.h>
 
 Scene::Scene() : camera(){
         Model* grid1 = new Primitive(PRIM_GRID);
@@ -93,7 +94,12 @@ void Scene::handleInputs(Renderer& renderer){
 
 void Scene::render(Renderer& renderer){
     for(Model* model : models){
-        model->render(renderer);
+        if(model->isOverlay()){ //this shouldn't be here but whatever.
+            model->render(renderer, &Renderer::renderOverlay);
+        }
+        else{
+            model->render(renderer);
+        }
     }
     int i = 0;
     for(Model* model : const_models){

--- a/src/graphics/Scene.cpp
+++ b/src/graphics/Scene.cpp
@@ -106,7 +106,7 @@ void Scene::render(Renderer& renderer){
     }
 
     if (selected_model >= 0 && selected_model < models.size() && highlight_selected_model){
-        models[selected_model]->doRenderPipeline(renderer, PL_TRIANGLES_HIGHLIGHT);
+        models[selected_model]->doRenderPipeline(renderer, PL_MESH_HIGHLIGHT);
     }
 }
 

--- a/src/graphics/Scene.cpp
+++ b/src/graphics/Scene.cpp
@@ -94,12 +94,7 @@ void Scene::handleInputs(Renderer& renderer){
 
 void Scene::render(Renderer& renderer){
     for(Model* model : models){
-        if(model->isOverlay()){ //this shouldn't be here but whatever.
-            model->render(renderer, &Renderer::renderOverlay);
-        }
-        else{
-            model->render(renderer);
-        }
+        model->render(renderer);
     }
     int i = 0;
     for(Model* model : const_models){
@@ -111,7 +106,7 @@ void Scene::render(Renderer& renderer){
     }
 
     if (selected_model >= 0 && selected_model < models.size() && highlight_selected_model){
-        models[selected_model]->render(renderer, &Renderer::renderHighlight);
+        models[selected_model]->render(renderer, PL_TRIANGLES_HIGHLIGHT);
     }
 }
 


### PR DESCRIPTION
previously, each model render function would get an identically inputted renderer function, and would pass all the low level information directly, like the opengl render type (GL_TRIANGLES).
This became a bit tedious when I wanted the option to decide different shader rendering options. rather than create a bunch of extra variables and methods for the mesh, I've combined it all into an enum **RenderPipeline**.

RenderPipeline is passed to a models DoRenderPipeline(...) (formerly render(...)), and here it is decided what rendering to do.
The previous calling of the renderer was moved to _render

All the Renderer::render functions have also been consolidated